### PR TITLE
targetfolder path updated

### DIFF
--- a/_posts/2016-01-01-vod.md
+++ b/_posts/2016-01-01-vod.md
@@ -108,7 +108,7 @@ Following is an example set of commands:
 ``` 
 pullStream uri=rtmp://<SERVER_ADDRESS>/vod/mp4:video2.mov keepAlive=1 localstreamname=DummyLive
 
-createhlsstream localstreamnames=DummyLive bandwidths=128 targetfolder=../evo-webroot/ groupname=hls playlisttype=rolling playlistLength=10 chunkLength=5
+createhlsstream localstreamnames=DummyLive bandwidths=128 targetfolder=/var/evo-webroot/ groupname=hls playlisttype=rolling playlistLength=10 chunkLength=5
 ```
 
 The corresponding link to access this HLS stream would then be:


### PR DESCRIPTION
Running on Ubuntu the ``targetfolder=../evo-webroot/`` wasn't working, the ``http://127.0.0.1:8888/hls/playlist.m3u8`` was returning ``File not found`` changing it to absolute path fix the issue.